### PR TITLE
range for DrawCall

### DIFF
--- a/examples/particles.html
+++ b/examples/particles.html
@@ -28,6 +28,13 @@
     <script src="../build/picogl.js"></script>
     <script src="utils/utils.js"></script>
     <link rel="stylesheet" href="../site/css/picogl-example.css"> 
+    <style>
+        #particle-controls {
+            position: absolute;
+            bottom: 20px;
+            right: 30px;
+        }
+    </style>
 </head>
 <body>
     <div id="example-title">
@@ -35,6 +42,11 @@
         <div>
             <a href="https://github.com/tsherif/picogl.js/blob/master/examples/particles.html">Source code</a>
         </div>
+    </div>
+    <div id="particle-controls">
+        <button onclick="setDrawRange(50000)">50,000 particles</button>
+        <button onclick="setDrawRange(100000)">100,000 particles</button>
+        <button onclick="setDrawRange(200000)">200,000 particles</button>
     </div>
     <canvas id="gl-canvas"></canvas>
     <script id="main-vs" type="x-shader/vs">
@@ -204,12 +216,19 @@
 
         var drawCall1 = app.createDrawCall(program, vertexArray1, PicoGL.POINTS)
         .transformFeedback(transformFeedback2)
-        .uniformBlock("Mass", massUniforms);
+        .uniformBlock("Mass", massUniforms)
+        .range(50000);
 
         var drawCall2 = app.createDrawCall(program, vertexArray2, PicoGL.POINTS)
         .transformFeedback(transformFeedback1)
-        .uniformBlock("Mass", massUniforms);
+        .uniformBlock("Mass", massUniforms)
+        .range(50000);
 
+        function setDrawRange(count) {
+            console.log(count);
+            drawCall1.range(count);
+            drawCall2.range(count);
+        }
 
         var currentDrawCall = drawCall1;
         function draw() {      
@@ -231,7 +250,6 @@
         }
 
         requestAnimationFrame(draw);
-            
 
     </script>
     <a href="https://github.com/tsherif/picogl.js" id="github-ribbon"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>

--- a/examples/particles.html
+++ b/examples/particles.html
@@ -217,17 +217,16 @@
         var drawCall1 = app.createDrawCall(program, vertexArray1, PicoGL.POINTS)
         .transformFeedback(transformFeedback2)
         .uniformBlock("Mass", massUniforms)
-        .range(50000);
+        .elementCount(50000);
 
         var drawCall2 = app.createDrawCall(program, vertexArray2, PicoGL.POINTS)
         .transformFeedback(transformFeedback1)
         .uniformBlock("Mass", massUniforms)
-        .range(50000);
+        .elementCount(50000);
 
         function setDrawRange(count) {
-            console.log(count);
-            drawCall1.range(count);
-            drawCall2.range(count);
+            drawCall1.elementCount(count);
+            drawCall2.elementCount(count);
         }
 
         var currentDrawCall = drawCall1;

--- a/src/draw-call.js
+++ b/src/draw-call.js
@@ -46,9 +46,8 @@ const CONSTANTS = require("./constants");
     @prop {number} textureCount The number of active textures for this draw call.
     @prop {GLEnum} primitive The primitive type being drawn.
     @prop {Object} appState Tracked GL state.
-    @prop {GLsizei} count The number of element/indices to draw.
-    @prop {GLsizei} instanceCount The number of instances to draw.
-    @prop {GLint} offset Starting offset to draw in array.
+    @prop {GLsizei} numElements The number of element to draw.
+    @prop {GLsizei} numInstances The number of instances to draw.
 */
 class DrawCall {
 
@@ -72,9 +71,8 @@ class DrawCall {
         this.textureCount = 0;
         this.primitive = primitive;
 
-        this.count = this.currentVertexArray.numElements;
-        this.instanceCount = this.currentVertexArray.numInstances;
-        this.offset = 0;
+        this.numElements = this.currentVertexArray.numElements;
+        this.numInstances = this.currentVertexArray.numInstances;
     }
 
     transformFeedback(transformFeedback) {
@@ -133,28 +131,35 @@ class DrawCall {
     }
 
     /**
-        Set the range of vertex array to be drawn
+        Set numElements property to allow number of elements to be drawn
 
         @method
-        @param {GLsizei} [count=0] Number of element/indices to render, 0 set to all.
-        @param {GLsizei} [instanceCount=0] Number of instance to render, 0 set to all.
-        @param {GLint} [offset=0] Starting offset to draw in array.
+        @param {GLsizei} [count=0] Number of element to draw, 0 set to all.
         @return {DrawCall} The DrawCall object.
     */
-    range(count = 0, instanceCount = 0, offset = 0) {
+    elementCount(count = 0) {
         if (count > 0) {
-            this.count = Math.min(count, this.currentVertexArray.numElements);
+            this.numElements = Math.min(count, this.currentVertexArray.numElements);
         } else {
-            this.count = this.currentVertexArray.numElements;
+            this.numElements = this.currentVertexArray.numElements;
         }
 
-        if (instanceCount > 0) {
-            this.instanceCount = Math.min(instanceCount, this.currentVertexArray.numInstances);
-        } else {
-            this.instanceCount = this.currentVertexArray.numInstances;
-        }
+        return this;
+    }
 
-        this.offset = Math.max(offset, 0);
+    /**
+        Set numInstances property to allow number of instances be drawn
+
+        @method
+        @param {GLsizei} [count=0] Number of instance to draw, 0 set to all.
+        @return {DrawCall} The DrawCall object.
+    */
+    instanceCount(count = 0) {
+        if (count > 0) {
+            this.numInstances = Math.min(count, this.currentVertexArray.numInstances);
+        } else {
+            this.numInstances = this.currentVertexArray.numInstances;
+        }
 
         return this;
     }
@@ -194,14 +199,14 @@ class DrawCall {
 
         if (this.currentVertexArray.instanced) {
             if (this.currentVertexArray.indexed) {
-                this.gl.drawElementsInstanced(this.primitive, this.count, this.currentVertexArray.indexType, this.offset, this.instanceCount);
+                this.gl.drawElementsInstanced(this.primitive, this.numElements, this.currentVertexArray.indexType, 0, this.numInstances);
             } else {
-                this.gl.drawArraysInstanced(this.primitive, this.offset, this.count, this.instanceCount);
+                this.gl.drawArraysInstanced(this.primitive, 0, this.numElements, this.numInstances);
             }
         } else if (this.currentVertexArray.indexed) {
-            this.gl.drawElements(this.primitive, this.count, this.currentVertexArray.indexType, this.offset);
+            this.gl.drawElements(this.primitive, this.numElements, this.currentVertexArray.indexType, 0);
         } else {
-            this.gl.drawArrays(this.primitive, this.offset, this.count);
+            this.gl.drawArrays(this.primitive, 0, this.numElements);
         }
 
         if (this.currentTransformFeedback) {


### PR DESCRIPTION
Was really sick of my integrated graphics laptop from being able to load the PicoGL main page because when the particle example was randomly picked my laptop can't handle 200,000 particles and it just freezes everything loading the page.

I then realized there was no way to set the count or offsets in the DrawCall object so decided to just add it first and then also demo it in the particle example while I was at it.

Didn't commit builds because of current cluster of stuff I have thrown at you in last few days it probably will just be more of a pain dealing with conflict merges in the build files