### PR TITLE
pixelStorei expects a GLint as pname instead of a boolean

### DIFF
--- a/src/cubemap.js
+++ b/src/cubemap.js
@@ -120,8 +120,8 @@ class Cubemap {
         }
 
         this.bind(0);
-        this.gl.pixelStorei(CONSTANTS.UNPACK_FLIP_Y_WEBGL, this.flipY);
-        this.gl.pixelStorei(CONSTANTS.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this.premultiplyAlpha);
+        this.gl.pixelStorei(CONSTANTS.UNPACK_FLIP_Y_WEBGL, Number(this.flipY));
+        this.gl.pixelStorei(CONSTANTS.UNPACK_PREMULTIPLY_ALPHA_WEBGL, Number(this.premultiplyAlpha));
         this.gl.texParameteri(CONSTANTS.TEXTURE_CUBE_MAP, CONSTANTS.TEXTURE_MAG_FILTER, this.magFilter);
         this.gl.texParameteri(CONSTANTS.TEXTURE_CUBE_MAP, CONSTANTS.TEXTURE_MIN_FILTER, this.minFilter);
         this.gl.texParameteri(CONSTANTS.TEXTURE_CUBE_MAP, CONSTANTS.TEXTURE_WRAP_S, this.wrapS);

--- a/src/texture.js
+++ b/src/texture.js
@@ -171,8 +171,8 @@ class Texture {
         this.gl.texParameteri(this.binding, CONSTANTS.TEXTURE_WRAP_R, this.wrapR);
         this.gl.texParameteri(this.binding, CONSTANTS.TEXTURE_COMPARE_FUNC, this.compareFunc);
         this.gl.texParameteri(this.binding, CONSTANTS.TEXTURE_COMPARE_MODE, this.compareMode);
-        this.gl.pixelStorei(CONSTANTS.UNPACK_FLIP_Y_WEBGL, this.flipY);
-        this.gl.pixelStorei(CONSTANTS.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this.premultiplyAlpha);
+        this.gl.pixelStorei(CONSTANTS.UNPACK_FLIP_Y_WEBGL, Number(this.flipY));
+        this.gl.pixelStorei(CONSTANTS.UNPACK_PREMULTIPLY_ALPHA_WEBGL, Number(this.premultiplyAlpha));
         if (this.minLOD !== null) {
             this.gl.texParameterf(this.binding, CONSTANTS.TEXTURE_MIN_LOD, this.minLOD);
         }


### PR DESCRIPTION
Hey,

I was looking through the source code of [texture.js](https://github.com/tsherif/picogl.js/blob/master/src/texture.js) as I am trying to port some of it to my Typescript project when I noticed that [`pixelStorei` expects a `GLint` as `pname`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/pixelStorei) instead of a boolean that is being passed in.

Internally the boolean probably already gets cast to an int (or the WebGL API is lenient with its types) but it seems like a good idea to be syntactically correct. For now I've opted to use `Number()` as it seems the most clear to me and I doubt it will have a major performance impact compared to other techniques mentioned here: https://stackoverflow.com/questions/7820683/convert-boolean-result-into-number-integer. Alternatively we could use `~~foo` or `foo & 1`.

Kind regards,

Tim