### PR TITLE
es6-in-browser-wo-build

### DIFF
--- a/examples/triangle_es6.html
+++ b/examples/triangle_es6.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PicoGL.js: Triangle</title>
+    <meta charset="utf-8">
+    <script src="utils/utils.js"></script>
+    <link rel="stylesheet" href="../site/css/picogl-example.css"> 
+</head>
+<!--
+  The MIT License (MIT)
+
+  Copyright (c) 2017 Tarek Sherif
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal in
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+  the Software, and to permit persons to whom the Software is furnished to do so,
+  subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<body>
+    <div id="example-title">
+        PicoGL.js Example: Triangle, using ES6 modules directly.
+        <div>
+            <a href="https://github.com/tsherif/picogl.js/blob/master/examples/triangle_es6.html">Source code</a>
+        </div>
+    </div>
+    <canvas id="gl-canvas"></canvas>
+    <script type="shader/vs" id="vs">
+        #version 300 es
+        
+        layout(location=0) in vec4 position;
+        layout(location=1) in vec3 color;
+        
+        out vec3 vColor; 
+        void main() {
+            vColor = color;
+            gl_Position = position;
+        }
+    </script>
+    <script type="shader/fs" id="fs">
+        #version 300 es
+        precision highp float;
+        
+        in vec3 vColor;
+        
+        out vec4 fragColor;
+        void main() {
+            fragColor = vec4(vColor, 1.0);
+        }
+    </script>
+    <script type="module">
+        import {PicoGL} from '../src/picogl.js'
+        var canvas = document.getElementById("gl-canvas");
+
+        if (!utils.testWebGL2()) {
+            console.error("WebGL 2 not available");
+            document.body.innerHTML = "This example requires WebGL 2 which is unavailable on this system."
+        }
+
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+        
+        var app = PicoGL.createApp(canvas)
+        .clearColor(0.0, 0.0, 0.0, 1.0);
+
+        window.onresize = function() {
+            app.resize(window.innerWidth, window.innerHeight);
+        }
+
+        // PROGRAM 
+        var vsSource =  document.getElementById("vs").text.trim();
+        var fsSource =  document.getElementById("fs").text.trim();
+        var program = app.createProgram(vsSource, fsSource);
+
+        // GEOMETRY IN VERTEX BUFFERS
+        var positions = app.createVertexBuffer(PicoGL.FLOAT, 2, new Float32Array([
+            -0.5, -0.5,
+             0.5, -0.5,
+             0.0, 0.5, 
+        ]));
+
+        var colors = app.createVertexBuffer(PicoGL.UNSIGNED_BYTE, 3, new Uint8Array([
+            255, 0, 0,
+            0, 255, 0,
+            0, 0, 255
+        ]));
+
+        // COMBINE VERTEX BUFFERS INTO VERTEX ARRAY
+        var triangleArray = app.createVertexArray()
+        .vertexAttributeBuffer(0, positions)
+        .vertexAttributeBuffer(1, colors, { normalized: true });
+
+        // CREATE DRAW CALL FROM PROGRAM AND VERTEX ARRAY
+        var drawCall = app.createDrawCall(program, triangleArray);
+
+        // DRAW
+        app.clear();
+        drawCall.draw();
+
+        // CLEANUP
+        program.delete();
+        positions.delete();
+        colors.delete();
+        triangleArray.delete();
+
+    </script>
+    <a href="https://github.com/tsherif/picogl.js" id="github-ribbon"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+    <script src="../site/js/iframe.js"></script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -21,20 +21,20 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL, COMPRESSED_TEXTURE_TYPES, WEBGL_INFO, DUMMY_OBJECT } from "./constants";
-import { Cubemap } from "./cubemap";
-import { DrawCall } from "./draw-call";
-import { Framebuffer } from "./framebuffer";
-import { Renderbuffer } from "./renderbuffer";
-import { Program } from "./program";
-import { Shader } from "./shader";
-import { Texture } from "./texture";
-import { Timer } from "./timer";
-import { TransformFeedback } from "./transform-feedback";
-import { UniformBuffer } from "./uniform-buffer";
-import { VertexArray } from "./vertex-array";
-import { VertexBuffer } from "./vertex-buffer";
-import { Query } from "./query";
+import { GL, COMPRESSED_TEXTURE_TYPES, WEBGL_INFO, DUMMY_OBJECT } from "./constants.js";
+import { Cubemap } from "./cubemap.js";
+import { DrawCall } from "./draw-call.js";
+import { Framebuffer } from "./framebuffer.js";
+import { Renderbuffer } from "./renderbuffer.js";
+import { Program } from "./program.js";
+import { Shader } from "./shader.js";
+import { Texture } from "./texture.js";
+import { Timer } from "./timer.js";
+import { TransformFeedback } from "./transform-feedback.js";
+import { UniformBuffer } from "./uniform-buffer.js";
+import { VertexArray } from "./vertex-array.js";
+import { VertexBuffer } from "./vertex-buffer.js";
+import { Query } from "./query.js";
 
 /**
     Primary entry point to PicoGL. An app will store all parts of the WebGL

--- a/src/cubemap.js
+++ b/src/cubemap.js
@@ -27,7 +27,7 @@ import {
     COMPRESSED_TEXTURE_TYPES,
     DUMMY_OBJECT,
     DUMMY_UNIT_ARRAY
-} from "./constants";
+} from "./constants.js";
 
 /**
     Cubemap for environment mapping.

--- a/src/draw-call.js
+++ b/src/draw-call.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL, WEBGL_INFO } from "./constants";
+import { GL, WEBGL_INFO } from "./constants.js";
 
 /**
     A DrawCall represents the program and values of associated

--- a/src/framebuffer.js
+++ b/src/framebuffer.js
@@ -21,9 +21,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
-import { Texture } from "./texture";
-import { Renderbuffer } from "./renderbuffer";
+import { GL } from "./constants.js";
+import { Texture } from "./texture.js";
+import { Renderbuffer } from "./renderbuffer.js";
 
 /**
     Offscreen drawing surface.

--- a/src/picogl.js
+++ b/src/picogl.js
@@ -23,8 +23,8 @@
 
 let webglInfoInitialized = false;
 
-import { GL, WEBGL_INFO } from "./constants";
-import { App } from "./app";
+import { GL, WEBGL_INFO } from "./constants.js";
+import { App } from "./app.js";
 
 /**
     Global PicoGL module. For convenience, all WebGL enums are stored

--- a/src/program.js
+++ b/src/program.js
@@ -21,14 +21,14 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
-import { Shader } from "./shader";
+import { GL } from "./constants.js";
+import { Shader } from "./shader.js";
 import { 
     SingleComponentUniform,
     MultiNumericUniform,
     MultiBoolUniform,
     MatrixUniform
-} from "./uniforms";
+} from "./uniforms.js";
 
 /**
     WebGL program consisting of compiled and linked vertex and fragment

--- a/src/query.js
+++ b/src/query.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 /**
     Generic query object.

--- a/src/renderbuffer.js
+++ b/src/renderbuffer.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 /**
     Offscreen drawing attachment.

--- a/src/shader.js
+++ b/src/shader.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 /**
     WebGL shader.

--- a/src/texture.js
+++ b/src/texture.js
@@ -27,7 +27,7 @@ import {
     COMPRESSED_TEXTURE_TYPES,
     DUMMY_OBJECT,
     DUMMY_UNIT_ARRAY
-} from "./constants";
+} from "./constants.js";
 
 /**
     General-purpose texture.

--- a/src/timer.js
+++ b/src/timer.js
@@ -21,8 +21,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
-import { Query } from "./query";
+import { GL } from "./constants.js";
+import { Query } from "./query.js";
 
 /**
     Rendering timer.

--- a/src/transform-feedback.js
+++ b/src/transform-feedback.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 /**
     Tranform feedback object.

--- a/src/uniform-buffer.js
+++ b/src/uniform-buffer.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 /**
     Storage for uniform data. Data is stored in std140 layout.

--- a/src/uniforms.js
+++ b/src/uniforms.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL } from "./constants";
+import { GL } from "./constants.js";
 
 // Classes to manage uniform value updates, including
 // caching current values.

--- a/src/vertex-array.js
+++ b/src/vertex-array.js
@@ -18,7 +18,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL, TYPE_SIZE, DUMMY_OBJECT } from "./constants";
+import { GL, TYPE_SIZE, DUMMY_OBJECT } from "./constants.js";
 
 /**
     Organizes vertex buffer and attribute state.

--- a/src/vertex-buffer.js
+++ b/src/vertex-buffer.js
@@ -21,7 +21,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 
-import { GL, TYPE_SIZE } from "./constants";
+import { GL, TYPE_SIZE } from "./constants.js";
 
 const INTEGER_TYPES = {
     [GL.BYTE]: true,


### PR DESCRIPTION
Add '.js' extensions to all `import from`.  Allows
consuming picogl directly from browser using es6 modules
without having to build.  See #135 