### PR TITLE
dont throw when setting non-existent uniform

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -315,7 +315,10 @@ export class Program {
 
     // Set the value of a uniform.
     uniform(name, value) {
-        this.uniforms[name].set(value);
+        // some uniforms are optimized out
+        if (this.uniforms[name]) {
+            this.uniforms[name].set(value);
+        }
 
         return this;
     }


### PR DESCRIPTION
The compiler often optimizes out unused uniforms from the shader source. These uniforms never make it into the `program`'s list of `this.uniforms`, resulting in a `cannot call set of undefined` exception when calling `program.uniform('missingUniform', value)`.

This issue seems to be coming up a lot for me, especially in situations where I have some map projection uniforms and helper functions slotted into the source by a third party. If I don't end up calling the helper functions that use the uniforms, the code will throw when the third party code tries to set those now-missing uniforms.