### PR TITLE
Fix type annotation for UniformBuffer.set

### DIFF
--- a/build/module/uniform-buffer.js
+++ b/build/module/uniform-buffer.js
@@ -186,7 +186,7 @@ export class UniformBuffer {
 
         @method
         @param {number} index Index in the layout of item to set.
-        @param {ArrayBufferView} value Value to store at the layout location.
+        @param {Array.<number>} value Value to store at the layout location.
         @return {UniformBuffer} The UniformBuffer object.
     */
     set(index, value) {

--- a/build/types.d.ts
+++ b/build/types.d.ts
@@ -2149,7 +2149,7 @@ export class UniformBuffer {
      * @param value - Value to store at the layout location.
      * @returns The UniformBuffer object.
      */
-    set(index: number, value: ArrayBufferView): UniformBuffer;
+    set(index: number, value: number[]): UniformBuffer;
     /**
      * Send stored buffer data to the GPU.
      * @returns The UniformBuffer object.

--- a/src/uniform-buffer.js
+++ b/src/uniform-buffer.js
@@ -186,7 +186,7 @@ export class UniformBuffer {
 
         @method
         @param {number} index Index in the layout of item to set.
-        @param {ArrayBufferView} value Value to store at the layout location.
+        @param {Array.<number>} value Value to store at the layout location.
         @return {UniformBuffer} The UniformBuffer object.
     */
     set(index, value) {


### PR DESCRIPTION
The type of `value` should be `number[]` instead of `ArrayBufferView` since it is passed to a `TypedArray.set`.