### PR TITLE
[npm] only ship build/ folder to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "email": "tareksherif@pm.me",
     "url": "http://tareksherif.net/"
   },
+  "files": [
+    "build"
+  ],
   "scripts": {
     "lint": "eslint src/*.js test/tests/*.js",
     "compile-module": "rimraf build/module && cpy src build/module && replace %%VERSION%% $npm_package_version build/module/picogl.js",


### PR DESCRIPTION
Related to https://github.com/tsherif/picogl.js/issues/185

Only ships the build/ folder to NPM and not source code, or ts/webpack config, nor the doc/website.

Reduces download time during `npm install` for users