### PR TITLE
Replace "GlEnum" with "GLenum"

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -38,7 +38,7 @@ import {
     @prop {WebGLRenderingContext} gl The WebGL context.
     @prop {WebGLProgram} program The WebGL program.
     @prop {array} transformFeedbackVaryings Names of transform feedback varyings, if any.
-    @prop {GlEnum} transformFeedbackMode Capture mode of the transform feedback.
+    @prop {GLenum} transformFeedbackMode Capture mode of the transform feedback.
     @prop {Object.<string, number>} attributeLocations Map of user-provided attribute names to indices, if any.
     @prop {Object} uniforms Map of uniform names to handles.
     @prop {Object} appState Tracked GL state.


### PR DESCRIPTION
I was seeing Typescript compilation errors because of this. Hopefully this change fixes the issue.

Great library, by the way! Thanks for creating it.