### PR TITLE
Support baseInstance/baseVertex draw and multidraw extension calls

### DIFF
--- a/examples/multi-draw-base-instance.html
+++ b/examples/multi-draw-base-instance.html
@@ -31,7 +31,7 @@
 -->
 <body>
     <div id="example-title">
-        PicoGL.js Example: Multi-draw
+        PicoGL.js Example: Multi-draw with base instance offsets
         <div>
             <a href="https://github.com/tsherif/picogl.js/blob/master/examples/instanced.html">Source code</a>
         </div>
@@ -67,8 +67,8 @@
     <script type="module">
         import { PicoGL } from "../src/picogl.js";
 
-        if (!testExtension("WEBGL_multi_draw_instanced") && !testExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance")) {
-            document.body.innerHTML = 'This example requires extension <b>WEBGL_multi_draw_instanced</b> which is not supported on this system. You may need to enable <b>WebGL Draft Extensions</b> in your browser, via <b><code>chrome://flags</code></b> in Google Chrome, or <b><code>about:config</code></b> in Firefox.';
+        if (!testExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance") || !testExtension("WEBGL_draw_instanced_base_vertex_base_instance")) {
+            document.body.innerHTML = 'This example requires extension <b>WEBGL_multi_draw_instanced_base_vertex_base_instance</b> which is not supported on this system. You may need to enable <b>WebGL Draft Extensions</b> in your browser, via <b><code>chrome://flags</code></b> in Google Chrome, or <b><code>about:config</code></b> in Firefox.';
         }
 
         let canvas = document.getElementById("gl-canvas");
@@ -125,10 +125,10 @@
         app.createPrograms([vsSource, fsSource]).then(([program]) => {
           let drawCall = app.createDrawCall(program, triangleArray)
           .drawRanges(
-            [0, 3, 1],
+            [0, 3, 1, 2],
+            [3, 6, 2, 1],
             [3, 6, 2],
             [0, 3, 3],
-            [3, 6, 3]
           );
 
           app.clear();

--- a/src/app.js
+++ b/src/app.js
@@ -1204,6 +1204,8 @@ export class App {
         // Draft extensions
         this.gl.getExtension("KHR_parallel_shader_compile");
         this.state.extensions.multiDrawInstanced = this.gl.getExtension("WEBGL_multi_draw_instanced");
+        this.state.extensions.drawInstancedBaseVertexBaseInstance = this.gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
+        this.state.extensions.multiDrawInstancedBaseVertexBaseInstance = this.gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
     }
 
     initContextListeners() {

--- a/src/picogl.js
+++ b/src/picogl.js
@@ -102,6 +102,8 @@ export const PicoGL = Object.assign({
             // Draft extensions
             WEBGL_INFO.PARALLEL_SHADER_COMPILE = Boolean(gl.getExtension("KHR_parallel_shader_compile"));
             WEBGL_INFO.MULTI_DRAW_INSTANCED = Boolean(gl.getExtension("WEBGL_multi_draw_instanced"));
+            WEBGL_INFO.DRAW_INSTANCED_BASE_VERTEX_BASE_INSTANCE = Boolean(gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance"));
+            WEBGL_INFO.MULTI_DRAW_INSTANCED_BASE_VERTEX_BASE_INSTANCE = Boolean(gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance"));
 
             webglInfoInitialized = true;
         }


### PR DESCRIPTION
This adds support for [WEBGL_draw_instanced_base_vertex_base_instance](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/) and 
[WEBGL_multi_draw_instanced_base_vertex_base_instance](https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/) via the `DrawCall.drawRanges` interface.  It resolves #197.

This change lets you specify the first vertex and/or instance in your range on a per-draw basis, like this:
```js
drawCall.drawRanges(
  [offset, numElements, numInstances, baseInstance, baseElement],
  ...
)
``` 

The multidraw+baseVertex+baseInstance extension calls will be used if they're available, since they cover the most use cases (and provide `gl_DrawID`).  Then if `baseVertices` or `baseInstances` have been set the non-multidraw baseVertex+baseInstance extension calls will be used.  If not, the existing draw call preference order (multidraw then non-multidraw) takes over.

I added an example at `examples/multi-draw-base-instance.html`:
![image](https://user-images.githubusercontent.com/389782/164568704-96eb3c91-d379-437d-b3f9-b450b7be00fb.png)

```js
let drawCall = app.createDrawCall(program, triangleArray)
  .drawRanges(
    [0, 3, 1, 2], // draw one instance starting at instance index 2
    [3, 6, 2, 1], // draw two instances starting at instance index 1
    [3, 6, 2], // draw two instances (implicitly starting at index 0) 
    [0, 3, 3], // draw three instances (implicitly starting at index 0)
  );
```

I tested this with the existing `examples/multi-draw.html` and `examples/multi-draw-base-instance.html`, and also spot checked the rest of the examples and didn't see anything broken. That said I didn't explicitly test the `drawElementsInstancedBaseVertexBaseInstanceWEBGL` and `multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL` calls, instead I just made sure they conformed to the API.