### PR TITLE
Stop using WEBGL_debug_renderer_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+- Stop using WEBGL_debug_renderer_info.
+
 ## v0.17.9
 - Fix type for Program transform feedback mode.
 
@@ -76,7 +80,7 @@
     - Deprecate `format` parameter to `App.createTexture*()` and `App.createCubemap()`. `internalFormat` is now the primary parameter. `type` and `format` will be automatically determined, and `type` can be overridden if desired.
     - Support for anisotropic filtering (EXT_texture_filter_anisotropic)
 - Support for getting platform translations of shaders (WEBGL_debug_shaders) via `Shader.translatedSource`, `Program.translatedVertexSource` and `Program.translatedFragmentSource`.
-- Renderer information now stored in `PicoGL.WEBGL_INFO.VENDOR` and `PicoGL.WEBGL_INFO.RENDERER`. 
+- Renderer information now stored in `PicoGL.WEBGL_INFO.VENDOR` and `PicoGL.WEBGL_INFO.RENDERER`.
 - Use recommended polling pattern for shader compilation and program linking.
 
 
@@ -100,7 +104,7 @@
 - `VertexArray`
     - Remove methods `vertexIntegerAttributeBuffer()`, `instanceIntegerAttributeBuffer()`, `vertexNormalizedAttributeBuffer()`, `instanceNormalizedAttributeBuffer()`
     - `vertexAttributeBuffer()` and `instanceAttributeBuffer()` can fully specify pointer information (size, type, etc.) via an optional `options` argument.
-- `VertexBuffer`  
+- `VertexBuffer`
     - Track whether they contain integer data based on the type provided. Used for attribute pointer.
     - `normalized()` and `unnormalized()` methods to indicate whether they contain normalized integer data.
 - `App.createInterleavedBuffer()` to create a buffer without any attribute pointer information (site, type, etc.).

--- a/src/picogl.js
+++ b/src/picogl.js
@@ -75,8 +75,8 @@ export const PicoGL = Object.assign({
                 gl.getParameter(GL.MAX_FRAGMENT_UNIFORM_VECTORS)
             );
             WEBGL_INFO.SAMPLES = gl.getParameter(GL.SAMPLES);
-            WEBGL_INFO.VENDOR = "(Unknown)";
-            WEBGL_INFO.RENDERER = "(Unknown)";
+            WEBGL_INFO.VENDOR = gl.getParameter(GL.VENDOR);
+            WEBGL_INFO.RENDERER = gl.getParameter(GL.RENDERER);
 
             // Extensions
             WEBGL_INFO.FLOAT_RENDER_TARGETS = Boolean(gl.getExtension("EXT_color_buffer_float"));
@@ -92,12 +92,6 @@ export const PicoGL = Object.assign({
 
             WEBGL_INFO.TEXTURE_ANISOTROPY = Boolean(gl.getExtension("EXT_texture_filter_anisotropic"));
             WEBGL_INFO.MAX_TEXTURE_ANISOTROPY = WEBGL_INFO.TEXTURE_ANISOTROPY ? gl.getParameter(GL.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1;
-
-            WEBGL_INFO.DEBUG_RENDERER_INFO = Boolean(gl.getExtension("WEBGL_debug_renderer_info"));
-            if (WEBGL_INFO.DEBUG_RENDERER_INFO) {
-                WEBGL_INFO.VENDOR = gl.getParameter(GL.UNMASKED_VENDOR_WEBGL);
-                WEBGL_INFO.RENDERER = gl.getParameter(GL.UNMASKED_RENDERER_WEBGL);
-            }
 
             // Draft extensions
             WEBGL_INFO.PARALLEL_SHADER_COMPILE = Boolean(gl.getExtension("KHR_parallel_shader_compile"));


### PR DESCRIPTION
This change fixes the following warning:

  WEBGL_debug_renderer_info is deprecated in Firefox and will be removed. Please use RENDERER.